### PR TITLE
Don't search default path when JsonCpp_DIR is provided

### DIFF
--- a/cmake/FindJsonCpp.cmake
+++ b/cmake/FindJsonCpp.cmake
@@ -32,14 +32,17 @@ if( JsonCpp_DIR )
     ${JsonCpp_DIR}/lib/MinSizeRel
     ${JsonCpp_DIR}/lib/RelWithDebInfo
     ${JsonCpp_DIR}/lib/Debug )
+  set( _jsoncpp_options NO_DEFAULT_PATH )
 endif( JsonCpp_DIR )
 
 find_path( JsonCpp_INCLUDE_DIR NAMES json/json.h
   HINTS ${_jsoncpp_include_dir}
-  PATH_SUFFIXES jsoncpp )
+  PATH_SUFFIXES jsoncpp
+  ${_jsoncpp_options} )
 
 find_library( JsonCpp_LIBRARY NAMES jsoncpp libjsoncpp
-  HINTS ${_jsoncpp_library} )
+  HINTS ${_jsoncpp_library}
+  ${_jsoncpp_options} )
 
 set( JsonCpp_INCLUDE_DIRS ${JsonCpp_INCLUDE_DIR} )
 set( JsonCpp_LIBRARIES ${JsonCpp_LIBRARY} )


### PR DESCRIPTION
If a JsonCpp is present in a default path on the computer,
find_package(JsonCpp) was selecting this one instead of the path
pointed by JsonCpp_DIR.
