### PR TITLE
Fix ITK targets within find_package()

### DIFF
--- a/cmake/ParameterSerializerConfig.cmake.in
+++ b/cmake/ParameterSerializerConfig.cmake.in
@@ -10,6 +10,9 @@ get_filename_component( ParameterSerializer_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE
 
 set( ParameterSerializer_INCLUDE_DIRS "@ParameterSerializer_INCLUDE_DIRS@" )
 
+find_package(ITK REQUIRED)
+set(ITK_FOUND FALSE)
+
 # We need to let CMake know the location of the json library.
 set( used_jsoncpp_config "@JsonCpp_DIR@/JsonCppConfig.cmake" )
 if( NOT DEFINED JsonCpp_LIBRARIES AND EXISTS "${used_jsoncpp_config}" )


### PR DESCRIPTION
GenerateCLP was failing to build with JsonCpp and ParameterSerializer using a static ITK.

Scanning dependencies of target GenerateCLP
[ 92%] Building CXX object GenerateCLP/CMakeFiles/GenerateCLP.dir/GenerateCLP.cxx.o
Linking CXX executable bin/GenerateCLP
/usr/bin/ld: cannot find -litkNetlibSlatec
/usr/bin/ld: cannot find -lITKStatistics
/usr/bin/ld: cannot find -lITKMesh
/usr/bin/ld: cannot find -litkzlib
/usr/bin/ld: cannot find -lITKMetaIO
/usr/bin/ld: cannot find -lITKSpatialObjects
...
